### PR TITLE
Put back gpg dependency

### DIFF
--- a/libraries/requirements.rb
+++ b/libraries/requirements.rb
@@ -72,7 +72,7 @@ class ChefRvmCookbook
         'suse' => {
           'default' => %w[automake binutils bison bzip2 libtool m4 make patch gdbm-devel glibc-devel libffi-devel
                           libopenssl-devel readline-devel zlib-devel sqlite3-devel
-                          gcc-c++ zlib libxml2-devel libxslt-devel llvm llvm-clang llvm-devel ]
+                          gcc-c++ zlib libxml2-devel libxslt-devel llvm llvm-clang llvm-devel]
         },
         %w[centos redhat fedora scientific amazon] => {
           'default' => %w[gcc-c++ patch readline readline-devel zlib zlib-devel

--- a/libraries/rvm_provider_mixin.rb
+++ b/libraries/rvm_provider_mixin.rb
@@ -1,7 +1,7 @@
 class ChefRvmCookbook
   module RvmProviderMixin
     def rvm
-      @rvm ||= ChefRvmCookbook::RvmSimpleEnvironment.new(new_resource.user, verbose: node['chef_rvm']['verbose'])
+      @rvm ||= ChefRvmCookbook::RvmSimpleEnvironment.new(new_resource.user, verbose: node['chef_rvm']['verbose'], keyserver: node['chef_rvm']['keyserver'])
     end
   end
 end

--- a/libraries/rvm_simple_environment_rvm.rb
+++ b/libraries/rvm_simple_environment_rvm.rb
@@ -37,6 +37,9 @@ class ChefRvmCookbook
       end
 
       def rvm_install
+        cmd = parent_shell_out("gpg --keyserver #{options[:keyserver] || 'hkp://keyserver.ubuntu.com:80'} --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3", shell_options)
+        cmd.error!
+
         temp_file = Tempfile.new('foo')
         begin
           parent_shell_out("curl -sSL https://get.rvm.io > #{temp_file.path}").error!

--- a/metadata.rb
+++ b/metadata.rb
@@ -23,6 +23,7 @@ depends 'sudo'
 depends 'apt'
 depends 'build-essential'
 depends 'chef_gem'
+depends 'gpg'
 depends 'curl'
 
 # if using jruby, java is required on system

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures rvm'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 # source_url 'https://github.com/MurgaNikolay/chef-rvm'
 # issues_url 'https://github.com/MurgaNikolay/chef-rvm/issues'
-version '2.0.0'
+version '2.1.0'
 
 recipe 'chef_rvm', 'Installs all'
 recipe 'chef_rvm::rvm', 'Installs the rvm for users'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,3 +1,4 @@
+include_recipe 'gpg'
 include_recipe 'apt'
 include_recipe 'build-essential'
 include_recipe 'curl'

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -1,6 +1,6 @@
 default_action :install
 
-property :gem, [String]
+property :gem_name, [String]
 property :version, [String, NilClass], default: nil
 property :user, [String], default: 'root'
 property :ruby_string, [String], required: true
@@ -11,22 +11,22 @@ action :install do
     rvm.gemset_create(ruby_string)
   end
 
-  if rvm.gem?(ruby_string, gem, version)
-    Chef::Log.debug("Gem #{gem} #{version} already installed on gemset #{ruby_string} for user #{user}.")
+  if rvm.gem?(ruby_string, gem_name, version)
+    Chef::Log.debug("Gem #{gem_name} #{version} already installed on gemset #{ruby_string} for user #{user}.")
   else
-    Chef::Log.debug("Install gem #{gem} #{version} on gemset #{ruby_string} for user #{user}.")
-    rvm.gem_install(ruby_string, gem, version)
+    Chef::Log.debug("Install gem #{gem_name} #{version} on gemset #{ruby_string} for user #{user}.")
+    rvm.gem_install(ruby_string, gem_name, version)
     updated_by_last_action(true)
   end
 end
 
 %i[update uninstall].each do |action_name|
   action action_name do
-    if rvm.gem?(ruby_string, gem, version)
-      Chef::Log.debug "#{action_name.to_s.capitalize} gem #{gem} #{version} from gemset #{ruby_string} for user #{user}."
+    if rvm.gem?(ruby_string, gem_name, version)
+      Chef::Log.debug "#{action_name.to_s.capitalize} gem #{gem_name} #{version} from gemset #{ruby_string} for user #{user}."
       updated_by_last_action(true)
     else
-      Chef::Log.debug "Gem #{gem} #{version} is not installed on gemset #{ruby_string} for user #{user}."
+      Chef::Log.debug "Gem #{gem_name} #{version} is not installed on gemset #{ruby_string} for user #{user}."
     end
   end
 end


### PR DESCRIPTION
> Not tracked in JIRA

### Scope of the PR

This PR puts back gpg dependency into cookbook, allowing us to verify gpg certificates for RVM while installing. It also introduces a fix for the gem resource property naming (instead of `gem` we now use `gem_name` which ensures compatibility with Chef 13).